### PR TITLE
util.puts is deprecated, and stderr is useful

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,11 +2,13 @@
 /*globals module require*/
 var exec = require('child_process').exec
   , fs   = require("fs")
-  , path = require("path")
-  , util = require("util");
+  , path = require("path");
 
-function puts(error, stdout/*, stderr*/) {
-  util.puts(stdout);
+function log(error, stdout, stderr) {
+  console.log(stdout);
+  if (stderr) {
+    console.log(stderr);
+  }
 }
 
 function valid_args (args) {
@@ -59,7 +61,7 @@ module.exports = function (root, interval, callback) {
       , interval: interval || 5007
       };
 
-  puts(null, "Watching " + root + " every " + opts.interval / 1000 + " seconds for changes...");
+  log(null, "Watching " + root + " every " + opts.interval / 1000 + " seconds for changes...");
 
   walk(root, function (err, dir, files) {
     files
@@ -71,12 +73,12 @@ module.exports = function (root, interval, callback) {
 };
 
 module.exports.exec = function notify (filename, command) {
-  puts(null, "\nChange made to: " + filename);
+  log(null, "\nChange made to: " + filename);
 
-  command && exec(command, puts);
+  command && exec(command, log);
 };
 
-module.exports.puts = puts;
+module.exports.log = log;
 
 // only exposed for testing purposes - if they get mangled so be it
 module.exports.valid = {


### PR DESCRIPTION
I know what you said about this repo, but... I also know that it's still out there for others to use, and this is just a minor improvement you may want to merge in. maybe. :hamburger: 

EDIT: I also made a change to make use of `stderr`

PS: thanks to @kherrick for the tip about `stderr` 
